### PR TITLE
Fix/starter

### DIFF
--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -15,7 +15,7 @@
     "@typechain/ethers-v5": "^11.0.0",
     "@typechain/hardhat": "^7.0.0",
     "chai": "^4.3.7",
-    "ethers": "^5.4.7",
+    "ethers": "5.4.7",
     "hardhat": "^2.14.0",
     "hardhat-gas-reporter": "^1.0.9",
     "solidity-coverage": "^0.8.2",

--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -19,6 +19,7 @@
     "hardhat": "^2.14.0",
     "hardhat-gas-reporter": "^1.0.9",
     "solidity-coverage": "^0.8.2",
-    "typechain": "^8.2.0"
+    "typechain": "^8.2.0",
+    "@openzeppelin/contracts": "^4.9.0"
   }
 }


### PR DESCRIPTION
- openzepplinを追加
- ethersのバージョンを6より小さいものに指定